### PR TITLE
remove chiphell.com

### DIFF
--- a/blacklist.txt
+++ b/blacklist.txt
@@ -118,7 +118,6 @@
 *://*.chcpd.com/*
 *://*.china.cn/*
 *://*.china2uk.com/*
-*://*.chiphell.com/*
 *://*.chiphells.com/*
 *://*.cjavapy.com/*
 *://*.cjkfd.top/*


### PR DESCRIPTION
chiphell.com is a tech forum where the majority of content is high-quality, user-created sharing. It's not a website that should be blocked. Thanks.